### PR TITLE
fix: change http-common/resp to stdresp

### DIFF
--- a/http-common/stdresp/error.go
+++ b/http-common/stdresp/error.go
@@ -1,4 +1,4 @@
-package resp
+package stdresp
 
 import (
 	"errors"

--- a/http-common/stdresp/meta.go
+++ b/http-common/stdresp/meta.go
@@ -1,4 +1,4 @@
-package resp
+package stdresp
 
 // Meta represents pagination metadata, with optional fields using omitempty
 type Meta struct {

--- a/http-common/stdresp/status.go
+++ b/http-common/stdresp/status.go
@@ -1,4 +1,4 @@
-package resp
+package stdresp
 
 const (
 	UnauthorizedStatus   = "UNAUTHORIZED"

--- a/http-common/stdresp/success.go
+++ b/http-common/stdresp/success.go
@@ -1,4 +1,4 @@
-package resp
+package stdresp
 
 import "net/http"
 


### PR DESCRIPTION
This PR changes the name of http-common/resp to http-common/stdresp to avoid conflicts with local variables.